### PR TITLE
refactor: Update favorites to fetch from backend API instead of local…

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,55 +1,16 @@
-import React, { useState, useEffect } from 'react'; // useEffect をインポート
+import React from 'react';
 import 'react-native-gesture-handler';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { TouchableOpacity, Text, View } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage'; // AsyncStorage をインポート
 
 import HomeScreen from './src/screens/HomeScreen';
 import FavoritesScreen from './src/screens/FavoritesScreen';
 import RecommendationsScreen from './src/screens/RecommendationsScreen';
 
 const Stack = createStackNavigator();
-const FAVORITES_KEY = '@favorites_list'; // 保存用のキーを定義
 
 const App = () => {
-  const [favorites, setFavorites] = useState([]);
-
-  // ★★★ 変更点①：アプリ起動時にデータを読み込む処理 ★★★
-  useEffect(() => {
-    const loadFavorites = async () => {
-      try {
-        const savedFavorites = await AsyncStorage.getItem(FAVORITES_KEY);
-        if (savedFavorites !== null) {
-          setFavorites(JSON.parse(savedFavorites));
-        }
-      } catch (e) {
-        console.error('Failed to load favorites.', e);
-      }
-    };
-    loadFavorites();
-  }, []);
-
-  // ★★★ 変更点②：お気に入りリストが更新されたらデータを保存する処理 ★★★
-  useEffect(() => {
-    const saveFavorites = async () => {
-      try {
-        await AsyncStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
-      } catch (e) {
-        console.error('Failed to save favorites.', e);
-      }
-    };
-    // 最初の読み込み時（favoritesが空の配列の時）には保存しないようにする
-    if (favorites.length > 0) {
-      saveFavorites();
-    }
-  }, [favorites]); // favorites の中身が変わるたびに実行
-
-  const handleAddToFavorites = (book) => {
-    if (!favorites.some(fav => fav.title === book.title)) {
-      setFavorites(currentFavorites => [...currentFavorites, book]);
-    }
-  };
 
   return (
     <NavigationContainer>
@@ -75,14 +36,13 @@ const App = () => {
             ),
           })}
         >
-          {props => <HomeScreen {...props} onAddToFavorites={handleAddToFavorites} />}
+          {props => <HomeScreen {...props} />}
         </Stack.Screen>
         <Stack.Screen
           name="Favorites"
           options={{ title: 'お気に入り一覧' }}
-        >
-          {props => <FavoritesScreen {...props} favorites={favorites} />}
-        </Stack.Screen>
+          component={FavoritesScreen}
+        />
         <Stack.Screen
           name="Recommendations"
           options={{ title: 'おすすめ一覧' }}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -15,7 +15,7 @@ const BookCard = ({ card }) => (
   </View>
 );
 
-const HomeScreen = ({ onAddToFavorites }) => {
+const HomeScreen = () => {
   const [books, setBooks] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -83,7 +83,6 @@ const HomeScreen = ({ onAddToFavorites }) => {
           cards={books}
           renderCard={(card) => (card ? <BookCard card={card} /> : null)}
           onSwipedRight={(cardIndex) => {
-            onAddToFavorites(books[cardIndex]);
             recordSwipe(books[cardIndex], true);
           }}
           onSwipedLeft={(cardIndex) => {


### PR DESCRIPTION
… state

- Remove favorites state management from App.tsx
- Refactor FavoritesScreen to fetch data from /favorites/{user_id} endpoint
- Remove onAddToFavorites prop from HomeScreen
- Add loading indicator for favorites API calls
- Use backend API as single source of truth for favorites data